### PR TITLE
GeigerDAQ: Add Python requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The suite consists of two types of codes:
 
  More specific information:
 
+ * requirements.txt -- Requirements for running the Python scripts
+ * requirements_rpi.txt -- Requirements for running the logger_GPIO.py file (on a Raspberry Pi)
  * logger.py -- reads data from the serial bus, performs analysis, writes to a file
  * logger\_barebone.py -- does the bare minimum of the above
  * logger\_println.py -- the older (less efficient but simpler) version of logger.py. Will be retired in the near future.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib
+numpy
+pyserial

--- a/requirements_rpi.txt
+++ b/requirements_rpi.txt
@@ -1,0 +1,4 @@
+matplotlib
+numpy
+pyserial
+RPI.GPIO


### PR DESCRIPTION
Add requirements.txt and requirements_rpi.txt (for RPi GPIO) files.

Signed-off-by: Gegham Zakaryan <zakaryan.2004@outlook.com>